### PR TITLE
Fix for supporting line-folding

### DIFF
--- a/src/ICalendarOrg/ZCiCal.php
+++ b/src/ICalendarOrg/ZCiCal.php
@@ -52,12 +52,17 @@ class ZCiCal
 			$eventcount = 0;
 			$eventpos = 0;
 
+			// We need to handle data folding, so let's detect when we need
+			// to unfold and keep track of what we're unfolding onto.
+			$lastdatakey = null;
+
 			foreach ($lines as $line)
 				{
 				if ('BEGIN:' == \substr($line, 0, 6))
 					{
 					// start new object
 					$name = \substr($line, 6);
+					$lastdatakey = null;
 
 					if ('VEVENT' == $name)
 						{
@@ -84,6 +89,7 @@ class ZCiCal
 				elseif ('END:' == \substr($line, 0, 4))
 					{
 					$name = \substr($line, 4);
+					$lastdatakey = null;
 
 					if ('VEVENT' == $name)
 						{
@@ -116,9 +122,19 @@ class ZCiCal
 							}
 						}
 					}
+				elseif (' ' == \substr($line, 0, 1))
+					{
+						// This appends to the previous line.
+						if ($lastdatakey !== null) {
+							$this->curnode->data[$lastdatakey]->values[
+								count($this->curnode->data[$lastdatakey]->values)-1
+							] .= ltrim($line);
+						}
+					}
 				else
 					{
 					$datanode = new \ICalendarOrg\ZCiCalDataNode($line);
+					$lastdatakey = $datanode->getName();
 
 					if ('VEVENT' == $this->curnode->getName())
 						{

--- a/tests/LinefoldingTest.php
+++ b/tests/LinefoldingTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the ICalendarOrg package
+ *
+ * (c) Bruce Wells
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source
+ * code
+ *
+ * Contributed by Tanabi @ GitHub
+ */
+class LinefoldingTest extends \PHPUnit\Framework\TestCase
+	{
+	/**
+	 * Test iCAL format with line folding (long lines)
+	 */
+	public function testLineFolding() : void
+		{
+		$sample = <<<EOS
+BEGIN:VCALENDAR
+PRODID;X-RICAL-TZSOURCE=TZINFO:-//Airbnb Inc//Hosting Calendar 0.8.8//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+DTEND;VALUE=DATE:20230611
+DTSTART;VALUE=DATE:20230514
+UID:xxx@airbnb.com
+DESCRIPTION:Reservation URL: https://www.airbnb.com/hosting/reservations/
+ details/xxx\\nPhone Number (Last 4 Digits): 0000
+SUMMARY:Reserved
+END:VEVENT
+END:VCALENDAR
+EOS
+		;
+
+		$test = new \ICalendarOrg\ZCiCal($sample);
+
+		// Make sure description 'reformed' correctly.
+		$this->assertCount(1, $test->tree->child);
+
+		$node = $test->tree->child[0];
+
+		// Make sure all expected fields are there
+		foreach (array('DTEND', 'DTSTART', 'UID', 'DESCRIPTION', 'SUMMARY')
+				 as $field) {
+			$this->assertArrayHasKey($field, $node->data);
+		}
+
+		// Make sure description matches
+		$this->assertEquals(
+			trim($node->data['DESCRIPTION']->values[0]),
+			'Reservation URL: https://www.airbnb.com/hosting/reservations/details/xxx\nPhone Number (Last 4 Digits): 0000'
+		);
+		}
+	}


### PR DESCRIPTION
The library, as is, doesn't currently support line folding.  Line folding is this...

https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html

Basically, a block like this:

```
DESCRIPTION:This is a lo
   ng description
    that exists on a long line.
```

Should be interpreted as:

```
DESCRIPTION:This is a long description that exists on a long line.
```

What the library does, currently, is make `$node->data` elements for each line, so there would be an element for `DESCRIPTION`, one for `  ng description`, and one for `   that exists on a long line.`

This PR fixes it and provides a unit test case for it.  I did my best to mimic the ... profoundly, inexcusably jenky formatting the original developer used.  I feel really dirty.